### PR TITLE
[dpugen] Logical changes to routing and ACL rules and Mappings

### DIFF
--- a/dpugen/dashgen/acl_group.py
+++ b/dpugen/dashgen/acl_group.py
@@ -18,9 +18,8 @@ class AclGroups(ConfBase):
         print('  Generating %s ...' % os.path.basename(__file__), file=sys.stderr)
         p = self.params
 
-        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT)):
-
-            for stage_in_index in range(p.ACL_NSG_COUNT):
+        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT * p.ENI_STEP, p.ENI_STEP)):  # Per ENI
+            for stage_in_index in range(p.ACL_NSG_COUNT):  # Per inbound stage
                 table_id = eni * 1000 + stage_in_index
 
                 self.num_yields += 1
@@ -31,7 +30,7 @@ class AclGroups(ConfBase):
                     'OP': 'SET'
                 }
 
-            for stage_out_index in range(p.ACL_NSG_COUNT):
+            for stage_out_index in range(p.ACL_NSG_COUNT):  # Per outbound stage
                 table_id = eni * 1000 + 500 + stage_out_index
 
                 self.num_yields += 1

--- a/dpugen/dashgen/dash_route_rule_table.py
+++ b/dpugen/dashgen/dash_route_rule_table.py
@@ -18,7 +18,7 @@ class RouteRules(ConfBase):
         p = self.params
         cp = self.cooked_params
 
-        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT)):
+        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT * p.ENI_STEP, p.ENI_STEP)):
             r_vni_id = eni + p.ENI_L2R_STEP
             vtep_remote = cp.PAR + eni_index * cp.IP_STEP1
             self.num_yields += 1

--- a/dpugen/dashgen/dash_route_table.py
+++ b/dpugen/dashgen/dash_route_table.py
@@ -22,19 +22,17 @@ class RouteTables(ConfBase):
         p = self.params
         cp = self.cooked_params
         nr_of_routes_prefixes = int(math.log(p.IP_ROUTE_DIVIDER_PER_ACL_RULE, 2))
-        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT)):
-            added_route_count = 0
+        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT * p.ENI_STEP, p.ENI_STEP)):  # Per ENI (64)
             vtep_eni = str(ipa(p.PAL) + int(ipa(p.IP_STEP1)) * eni_index)
-            for table_index in range(1, (p.ACL_NSG_COUNT*2+1)):
-                for acl_index in range(1, (p.ACL_RULES_NSG+1)):
-                    ip_map_count = 0
-                    remote_ip = cp.IP_R_START + eni_index * cp.IP_STEP_ENI + (table_index - 1) * cp.IP_STEP_NSG + (acl_index - 1) * cp.IP_STEP_ACL
-                    no_of_route_groups = p.IP_PER_ACL_RULE * 2 // p.IP_ROUTE_DIVIDER_PER_ACL_RULE
+            added_route_count = 0
+            for table_index in range(p.ACL_NSG_COUNT):  # Per outbound group (5)
+                for acl_index in range(p.ACL_RULES_NSG // 2):  # Per even rule (1000 / 2)
+                    remote_ip = cp.IP_R_START + (eni_index * cp.IP_STEP_ENI) + (table_index * cp.IP_STEP_NSG) + (acl_index * cp.IP_STEP_ACL)
+                    no_of_route_groups = p.IP_PER_ACL_RULE // (p.IP_ROUTE_DIVIDER_PER_ACL_RULE // 2)
                     for ip_index in range(0, no_of_route_groups):
-                        ip_prefix = remote_ip - 1 + ip_index * p.IP_ROUTE_DIVIDER_PER_ACL_RULE * cp.IP_STEP1
+                        ip_prefix = (remote_ip - 1) + (ip_index * p.IP_ROUTE_DIVIDER_PER_ACL_RULE * cp.IP_STEP1)
                         for prefix_index in range(nr_of_routes_prefixes, 0, -1):
-                            # nr_of_ips = int(math.pow(2, prefix_index-1))
-                            nr_of_ips = 1 << (prefix_index-1)
+                            nr_of_ips = 1 << (prefix_index - 1)
                             mask = 32 - prefix_index + 1
                             if mask == 32:
                                 ip_prefix = ip_prefix + 1
@@ -54,7 +52,7 @@ class RouteTables(ConfBase):
                                 self.num_yields += 1
                                 yield {
                                     "DASH_ROUTE_TABLE:eni-%d:%s/%d" % (eni, ip_prefix, mask): {
-                                        "action_type": "vnet",
+                                        "action_type": "vnet_direct",
                                         "vnet": "vnet-%d" % (eni + p.ENI_L2R_STEP),
                                         "overlay_ip": vtep_eni
                                     },
@@ -63,11 +61,10 @@ class RouteTables(ConfBase):
 
                             added_route_count += 1
                             ip_prefix = ip_prefix + cp.IP_STEP1 * nr_of_ips
-                            ip_map_count += int(math.pow(2, (32 - mask)))
 
-                    # TODO1: transition between mapped and routed ips
+                    # TODO: transition between mapped and routed ips
 
-            # TODO: write condition check here to add a default route if no route was added so curent ENI'
+            # TODO: write condition check here to add a default route if no route was added to current ENI'
             if added_route_count == 0:
                 remote_ip_prefix = cp.IP_R_START + eni_index * cp.IP_STEP_ENI
                 self.num_yields += 1
@@ -78,37 +75,6 @@ class RouteTables(ConfBase):
                     },
                     "OP": "SET"
                 }
-            # route_layers = deepcopy(
-            #     {
-            #         "Name": "LAYER_%d_ROUTE" % eni, "Type": 1,
-            #         "Groups": [
-            #             {
-            #                 "Name": "GROUP_%d_OUT_ROUTE" % eni,
-            #                 "Type": 0, "Direction": 0,
-            #                 "Rules": {
-            #                     "subnet_routes": routes
-            #                 }
-            #             },
-            #             {
-            #                 "Name": "GROUP_%d_IN_ROUTE" % eni,
-            #                 "Type": 0,
-            #                 "Direction": 1,
-            #                 "Rules": [
-            #                     {
-            #                         "Name": "RULE_900%d_IN_ROUTE" % eni,
-            #                         "Priority": 1,
-            #                         "Action": 2,
-            #                         "Conditions": [
-            #                             {
-            #                                 "VNIKeyList": [eni, (eni + ENI_L2R_STEP)]
-            #                             }
-            #                         ]
-            #                     }
-            #                 ]
-            #             }
-            #         ]
-            #     }
-            # )
 
 
 if __name__ == "__main__":

--- a/dpugen/dashgen/dash_vnet_mapping_table.py
+++ b/dpugen/dashgen/dash_vnet_mapping_table.py
@@ -23,35 +23,30 @@ class Mappings(ConfBase):
         p = self.params
         cp = self.cooked_params
 
-        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT * p.ENI_STEP, p.ENI_STEP)):
-            #debug_file = io.open('macs_for_eni_%d.txt' % eni, "wt")
-            vtep_eni = str(ipa(p.PAL) + int(ipa(p.IP_STEP1)) * eni_index)
-            # vtep_remote = cp.PAR + eni_index * cp.IP_STEP1
+        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT * p.ENI_STEP, p.ENI_STEP)):  # Per ENI
             vtep_remote = str(ipa(p.PAR) + int(ipa(p.IP_STEP1)) * eni_index)
-
+            vtep_eni = str(ipa(p.PAL) + int(ipa(p.IP_STEP1)) * eni_index)
             r_vni_id = eni + p.ENI_L2R_STEP
+
             # 1 in 4 enis will have all its ips mapped
             if (eni % 4) == 1:
                 # mapped IPs
                 print(f'    mapped:eni:{eni}', file=sys.stderr)
-                for nsg_index in range(1, (p.ACL_NSG_COUNT*2+1)):
-                    for acl_index in range(1, (p.ACL_RULES_NSG//2+1)):
-                        remote_ip_a = ipa(p.IP_R_START) + eni_index * int(ipa(p.IP_STEP_ENI)) + \
-                            (nsg_index - 1) * int(ipa(p.IP_STEP_NSG)) + (acl_index - 1) * int(ipa(p.IP_STEP_ACL))
+                for nsg_index in range(p.ACL_NSG_COUNT):  # Per outbound stage
+                    for acl_index in range(p.ACL_RULES_NSG // 2):  # Per half of the rules
+                        remote_ip_a = ipa(p.IP_R_START) + (eni_index * int(ipa(p.IP_STEP_ENI))) + \
+                                      (nsg_index * int(ipa(p.IP_STEP_NSG))) + (acl_index * int(ipa(p.IP_STEP_ACL)))
                         remote_mac_a = str(
                             maca(
                                 int(maca(p.MAC_R_START)) +
                                 eni_index * int(maca(p.ENI_MAC_STEP)) +
-                                (nsg_index - 1) * int(maca(p.ACL_NSG_MAC_STEP)) +
-                                (acl_index - 1) * int(maca(p.ACL_POLICY_MAC_STEP))
+                                nsg_index * int(maca(p.ACL_NSG_MAC_STEP)) +
+                                acl_index * int(maca(p.ACL_POLICY_MAC_STEP))
                             )
                         ).replace('-', ':')
 
-                        #debug_file.write('############ ALLOW\n')
-                        # mapping for deny ip
-                        # if you want to test that packets are being dropped because of the acl rule keep it
-                        # if you want to test that packets are being dropped because no mapping you can comment this area
-                        for i in range(p.IP_MAPPED_PER_ACL_RULE):
+                        # Allow
+                        for i in range(p.IP_MAPPED_PER_ACL_RULE):  # Per rule prefix
                             remote_expanded_ip = str(remote_ip_a + i * 2)
                             remote_expanded_mac = str(
                                 maca(
@@ -69,28 +64,6 @@ class Mappings(ConfBase):
                                 },
                                 "OP": "SET"
                             }
-                            #debug_file.write(remote_expanded_mac + '\n')
-
-                        #debug_file.write('############ DENNY\n')
-                        for i in range(p.IP_MAPPED_PER_ACL_RULE):
-                            remote_expanded_ip = str(remote_ip_a + i * 2 -1)
-                            remote_expanded_mac = str(
-                                maca(
-                                    int(maca(remote_mac_a)) + i * 2 - 1
-                                )
-                            ).replace('-', ':')
-
-                            self.num_yields += 1
-                            yield {
-                                "DASH_VNET_MAPPING_TABLE:vnet-%d:%s" % (r_vni_id, remote_expanded_ip): {
-                                    "routing_type": "vnet_encap",
-                                    "underlay_ip": str(vtep_remote),
-                                    "mac_address": remote_expanded_mac,
-                                    "use_dst_vni": "true"
-                                },
-                                "OP": "SET"
-                            }
-                            #debug_file.write(remote_expanded_mac + '\n')
 
             # 3 in 4 enis will have just mapping for gateway ip, for ip that are only routed and not mapped
             else:
@@ -113,8 +86,6 @@ class Mappings(ConfBase):
                     },
                     "OP": "SET"
                 }
-                #debug_file.write(remote_expanded_mac + '\n')
-            #debug_file.close()
 
 
 if __name__ == '__main__':

--- a/dpugen/dashgen/dash_vnet_table.py
+++ b/dpugen/dashgen/dash_vnet_table.py
@@ -17,25 +17,15 @@ class Vnets(ConfBase):
         print('  Generating %s ...' % os.path.basename(__file__), file=sys.stderr)
         p = self.params
 
-        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT)):
-            r_vni_id = p.ENI_L2R_STEP + eni            
+        for eni_index, eni in enumerate(range(p.ENI_START, p.ENI_START + p.ENI_COUNT * p.ENI_STEP, p.ENI_STEP)):
+            r_vni_id = p.ENI_L2R_STEP + eni
             self.num_yields += 1
             yield {
-                'DASH_VNET_TABLE:vnet-%d' % eni: {
+                'DASH_VNET_TABLE:vnet-%d' % r_vni_id: {
                     'vni': r_vni_id,
                 },
                 'OP': 'SET'
             }
-
- #           self.num_yields += 1
-#            r_vni_id = p.ENI_L2R_STEP + eni
-#
- #           yield {
- #               'DASH_VNET_TABLE:vnet-%d' % r_vni_id: {
-  #                  'vni': r_vni_id,
- #               },
-  #              'OP': 'SET'
-  #          }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
acl_group.py
- Fixed ENI iterations to handle ENI step size
- Added comments

acl_rule.py
- Fixed ENI iterations to handle ENI step size
- Removed "dead" code
- Dividing ip_index by 2 to fix issue where IP_STEP_ACL step was incremented by 0.0.2.0 instead of 0.0.1.0

dash_eni_table.py
- Cosmetic changes
- Since there's 1 VNET per ENI using the correct one now

dash_route_rule_table.py
- Fixed ENI iterations to handle ENI step size

dash_route_table.py
- Fixed ENI iterations to handle ENI step size
- Iterating and creating routes only over outbound IPs - only 5 stages are outbound

dash_vnet_mapping_table.py
- Cosmetic changes
- Remove denied ca_to_pa from code

dash_vnet_table.py
- Fixed ENI iterations to handle ENI step size
- Fixed vnet name